### PR TITLE
Add translation endpoints and issue utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ make format
 ### Endpoints
 
 - `GET /health` - Vérification de santé du service
+- `GET /locales` - Liste des locales disponibles
+- `GET /translations/<locale>` - Toutes les traductions pour une locale
+- `GET /translations/<locale>/<key>` - Traduction spécifique pour une clé
 
 ### Format des Réponses
 
@@ -61,6 +64,9 @@ make format
   "meta": null
 }
 ```
+
+Les locales et traductions sont chargées depuis `data/translations.json`,
+ce qui permet de les maintenir facilement dans le dépôt.
 
 ## 🔧 Développement
 

--- a/data/git_issues.json
+++ b/data/git_issues.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": 101,
+    "title": "Health check endpoint",
+    "status": "closed",
+    "implemented": true,
+    "priority": "P1",
+    "description": "Expose a /health endpoint reporting service status.",
+    "notes": "Endpoint implemented in src/main.py and covered by tests/test_health.py."
+  },
+  {
+    "id": 102,
+    "title": "List supported locales",
+    "status": "closed",
+    "implemented": true,
+    "priority": "P2",
+    "description": "Provide an endpoint returning all locales supported by the localization service.",
+    "notes": "Resolved by the /locales endpoint which serves locales from data/translations.json."
+  },
+  {
+    "id": 103,
+    "title": "Fetch translations by locale and key",
+    "status": "closed",
+    "implemented": true,
+    "priority": "P1",
+    "description": "Allow clients to retrieve translations for a locale or a specific key.",
+    "notes": "Implemented via /translations/<locale> and /translations/<locale>/<key> endpoints."
+  }
+]

--- a/data/translations.json
+++ b/data/translations.json
@@ -1,0 +1,17 @@
+{
+  "en": {
+    "greeting": "Hello",
+    "farewell": "Goodbye",
+    "thanks": "Thank you"
+  },
+  "fr": {
+    "greeting": "Bonjour",
+    "farewell": "Au revoir",
+    "thanks": "Merci"
+  },
+  "es": {
+    "greeting": "Hola",
+    "farewell": "Adiós",
+    "thanks": "Gracias"
+  }
+}

--- a/src/issues.py
+++ b/src/issues.py
@@ -1,0 +1,137 @@
+"""Utilities to inspect and update the local Git issues list.
+
+This module provides helper functions that read the mocked Git Issues
+list stored in :mod:`data/git_issues.json`. It is intentionally small and
+framework agnostic so that the logic can be reused both by the Flask
+application and command-line scripts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Iterable, List, Sequence
+import json
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+ISSUES_FILE = BASE_DIR / 'data' / 'git_issues.json'
+
+
+@dataclass
+class Issue:
+    """Representation of a Git issue entry."""
+
+    id: int
+    title: str
+    status: str
+    implemented: bool
+    description: str | None = None
+    notes: str | None = None
+    priority: str | None = None
+
+    @property
+    def is_open(self) -> bool:
+        """Return ``True`` when the issue is still open."""
+
+        return self.status.lower() == 'open'
+
+    def close(self, note: str | None = None) -> None:
+        """Mark the issue as closed and optionally append a note."""
+
+        self.status = 'closed'
+        self.implemented = True
+        if note:
+            self.notes = note
+
+
+def load_issues(path: Path = ISSUES_FILE) -> List[Issue]:
+    """Load issues from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the JSON file storing the issues list.
+    """
+
+    with path.open('r', encoding='utf-8') as handle:
+        payload = json.load(handle)
+    return [Issue(**item) for item in payload]
+
+
+def save_issues(issues: Sequence[Issue], path: Path = ISSUES_FILE) -> None:
+    """Persist ``issues`` into ``path`` in JSON format."""
+
+    serializable = [asdict(issue) for issue in issues]
+    with path.open('w', encoding='utf-8') as handle:
+        json.dump(serializable, handle, indent=2, ensure_ascii=False)
+
+
+def list_open_issues(issues: Iterable[Issue]) -> List[Issue]:
+    """Return a list containing only open issues."""
+
+    return [issue for issue in issues if issue.is_open]
+
+
+def close_implemented_issues(issues: Sequence[Issue]) -> List[Issue]:
+    """Close every issue that is already implemented.
+
+    The function mutates a shallow copy of ``issues`` to avoid side
+    effects when the caller still needs the original list.
+    """
+
+    updated = [Issue(**asdict(issue)) for issue in issues]
+    for issue in updated:
+        if issue.implemented and issue.is_open:
+            issue.close(note='Automatically closed because implementation exists.')
+    return updated
+
+
+def complete_issue(issues: Sequence[Issue], issue_id: int, note: str | None = None) -> List[Issue]:
+    """Mark the issue identified by ``issue_id`` as completed.
+
+    The function returns a new list where the targeted issue is updated.
+    """
+
+    updated = [Issue(**asdict(issue)) for issue in issues]
+    for issue in updated:
+        if issue.id == issue_id:
+            issue.close(note=note)
+            break
+    else:  # pragma: no cover - defensive branch
+        raise ValueError(f'Issue {issue_id} not found')
+    return updated
+
+
+def summarize_open_issues(issues: Sequence[Issue]) -> str:
+    """Produce a human readable summary of open issues."""
+
+    open_issues = list_open_issues(issues)
+    if not open_issues:
+        return 'No open issues 🎉'
+
+    lines = ['Open issues:']
+    for issue in open_issues:
+        parts = [f"#{issue.id}", issue.title]
+        if issue.priority:
+            parts.append(f'[{issue.priority}]')
+        lines.append(' - ' + ' '.join(parts))
+    return '\n'.join(lines)
+
+
+def close_and_complete_all(path: Path = ISSUES_FILE) -> List[Issue]:
+    """Utility used by maintenance scripts.
+
+    Loads the issues file, closes issues already implemented and persists
+    the result. This mirrors the manual workflow requested in the task
+    description.
+    """
+
+    issues = load_issues(path)
+    closed = close_implemented_issues(issues)
+    save_issues(closed, path)
+    return closed
+
+
+if __name__ == '__main__':  # pragma: no cover - manual usage helper
+    issues = load_issues()
+    print(summarize_open_issues(issues))

--- a/src/main.py
+++ b/src/main.py
@@ -1,18 +1,36 @@
-"""
-umbra-localization-service - Service d'internationalisation et traductions
-"""
+"""umbra-localization-service - Service d'internationalisation et traductions."""
+
+from __future__ import annotations
+
+import json
 import os
+from pathlib import Path
 from flask import Flask, jsonify
 from flask_cors import CORS
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+TRANSLATIONS_FILE = BASE_DIR / 'data' / 'translations.json'
+
+
+def load_translations() -> dict[str, dict[str, str]]:
+    """Load translations from the JSON file shipped with the project."""
+
+    if not TRANSLATIONS_FILE.exists():  # pragma: no cover - guardrail
+        raise FileNotFoundError(f'Translations file missing at {TRANSLATIONS_FILE}')
+
+    with TRANSLATIONS_FILE.open('r', encoding='utf-8') as handle:
+        return json.load(handle)
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
     CORS(app)
-    
+
     # Configuration
     app.config['DEBUG'] = os.getenv('FLASK_DEBUG', '0') == '1'
-    
+    app.config['TRANSLATIONS'] = load_translations()
+
     # Health check endpoint
     @app.route('/health')
     def health():
@@ -22,11 +40,88 @@ def create_app() -> Flask:
                 'status': 'healthy',
                 'service': 'umbra-localization-service'
             },
-            'message': 'Service en bonne santé'
+            'message': 'Service en bonne santé',
+            'error': None,
+            'meta': None
         }), 200
-    
-    # TODO: Ajouter les routes spécifiques au service
-    
+
+    @app.route('/locales')
+    def locales():
+        translations = app.config['TRANSLATIONS']
+        locales_list = sorted(translations.keys())
+        return jsonify({
+            'success': True,
+            'data': {
+                'locales': locales_list
+            },
+            'message': 'Locales disponibles récupérées',
+            'error': None,
+            'meta': {
+                'count': len(locales_list)
+            }
+        }), 200
+
+    @app.route('/translations/<locale>')
+    def translations_for_locale(locale: str):
+        translations = app.config['TRANSLATIONS']
+        locale_data = translations.get(locale)
+        if locale_data is None:
+            return jsonify({
+                'success': False,
+                'data': None,
+                'message': f'Locale "{locale}" inconnue',
+                'error': 'locale_not_found',
+                'meta': None
+            }), 404
+
+        return jsonify({
+            'success': True,
+            'data': {
+                'locale': locale,
+                'translations': locale_data
+            },
+            'message': 'Traductions récupérées',
+            'error': None,
+            'meta': {
+                'count': len(locale_data)
+            }
+        }), 200
+
+    @app.route('/translations/<locale>/<key>')
+    def translation_by_key(locale: str, key: str):
+        translations = app.config['TRANSLATIONS']
+        locale_data = translations.get(locale)
+        if locale_data is None:
+            return jsonify({
+                'success': False,
+                'data': None,
+                'message': f'Locale "{locale}" inconnue',
+                'error': 'locale_not_found',
+                'meta': None
+            }), 404
+
+        value = locale_data.get(key)
+        if value is None:
+            return jsonify({
+                'success': False,
+                'data': None,
+                'message': f'Clé "{key}" introuvable pour la locale {locale}',
+                'error': 'key_not_found',
+                'meta': None
+            }), 404
+
+        return jsonify({
+            'success': True,
+            'data': {
+                'locale': locale,
+                'key': key,
+                'value': value
+            },
+            'message': 'Traduction récupérée',
+            'error': None,
+            'meta': None
+        }), 200
+
     return app
 
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,0 +1,82 @@
+"""Tests for the Git issues helper module."""
+from pathlib import Path
+
+import json
+
+import pytest
+
+from src import issues as issues_module
+from src.issues import (
+    Issue,
+    close_implemented_issues,
+    complete_issue,
+    list_open_issues,
+    load_issues,
+    save_issues,
+    summarize_open_issues,
+)
+
+
+@pytest.fixture
+def sample_issues(tmp_path: Path) -> list[Issue]:
+    payload = [
+        {
+            'id': 1,
+            'title': 'Already implemented feature',
+            'status': 'open',
+            'implemented': True,
+            'priority': 'P1'
+        },
+        {
+            'id': 2,
+            'title': 'Missing functionality',
+            'status': 'open',
+            'implemented': False,
+            'priority': 'P2'
+        }
+    ]
+    issues_path = tmp_path / 'issues.json'
+    issues_path.write_text(json.dumps(payload), encoding='utf-8')
+
+    original_path = issues_module.ISSUES_FILE
+    issues_module.ISSUES_FILE = issues_path
+    try:
+        yield load_issues(issues_path)
+    finally:
+        issues_module.ISSUES_FILE = original_path
+
+
+def test_list_open_issues_filters_by_status(sample_issues):
+    open_issues = list_open_issues(sample_issues)
+    assert len(open_issues) == 2
+    assert all(issue.status == 'open' for issue in open_issues)
+
+
+def test_close_implemented_issues_marks_entries(sample_issues):
+    closed = close_implemented_issues(sample_issues)
+    issue_one = next(issue for issue in closed if issue.id == 1)
+    assert issue_one.status == 'closed'
+    assert issue_one.implemented is True
+
+
+def test_complete_issue_updates_note(sample_issues):
+    closed = complete_issue(sample_issues, issue_id=2, note='Implemented during tests')
+    issue_two = next(issue for issue in closed if issue.id == 2)
+    assert issue_two.status == 'closed'
+    assert issue_two.notes == 'Implemented during tests'
+
+
+def test_summarize_open_issues_handles_empty_list(sample_issues):
+    all_closed = close_implemented_issues(sample_issues)
+    all_closed = complete_issue(all_closed, issue_id=2)
+    summary = summarize_open_issues(all_closed)
+    assert summary == 'No open issues 🎉'
+
+
+def test_save_and_load_roundtrip(tmp_path: Path, sample_issues):
+    output_path = tmp_path / 'saved.json'
+    save_issues(sample_issues, output_path)
+    reloaded = load_issues(output_path)
+    assert [(issue.id, issue.status) for issue in reloaded] == [
+        (issue.id, issue.status) for issue in sample_issues
+    ]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,47 @@
+"""Tests for translation related endpoints."""
+
+def test_list_locales_endpoint(client):
+    response = client.get('/locales')
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert data['success'] is True
+    assert 'locales' in data['data']
+    assert data['data']['locales'] == sorted(data['data']['locales'])
+    assert data['meta']['count'] == len(data['data']['locales'])
+
+
+def test_translations_for_known_locale(client):
+    response = client.get('/translations/en')
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert data['success'] is True
+    assert data['data']['locale'] == 'en'
+    assert 'greeting' in data['data']['translations']
+
+
+def test_translations_for_unknown_locale(client):
+    response = client.get('/translations/it')
+    assert response.status_code == 404
+
+    data = response.get_json()
+    assert data['success'] is False
+    assert data['error'] == 'locale_not_found'
+
+
+def test_translation_by_key(client):
+    response = client.get('/translations/fr/thanks')
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert data['data']['value'] == 'Merci'
+    assert data['data']['key'] == 'thanks'
+
+
+def test_translation_by_key_missing_key(client):
+    response = client.get('/translations/fr/unknown-key')
+    assert response.status_code == 404
+
+    data = response.get_json()
+    assert data['error'] == 'key_not_found'


### PR DESCRIPTION
## Summary
- add helper module and fixture data to manage the mocked Git Issues list
- expose new /locales and /translations endpoints with bundled translation data
- expand automated coverage with tests for issue utilities and translation endpoints while documenting the API updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97e75ed848332928dc9c6b448ad99